### PR TITLE
[node-v6] Add support to Node v6 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
  - "0.10"
  - "4"
+ - "6"
 
 addons:
   apt:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "generic-pool": "~2.4.1",
         "request": "2.x",
         "srs": "1.x",
-        "zipfile": "~0.5.5",
+        "zipfile": "mapbox/node-zipfile#master",
         "sqlite3": "2.x || 3.x",
         "mime": "~1.2.11",
         "mkdirp": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "generic-pool": "~2.4.1",
         "request": "2.x",
         "srs": "1.x",
-        "zipfile": "mapbox/node-zipfile#master",
+        "zipfile": "0.5.10",
         "sqlite3": "2.x || 3.x",
         "mime": "~1.2.11",
         "mkdirp": "~0.5.0",

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -25,7 +25,7 @@ it('correctly handles invalid json', function(done) {
     };
 
     millstone.resolve(options, function(err, resolved) {
-        assert.ok(err.message.search("error: 'Unexpected token ]'") != -1);
+        assert.ok(err.message.search("error: 'Unexpected token ]") != -1);
         done();
     });
 });


### PR DESCRIPTION
- Use the latest version of Mapbox's upstream
- Support Node v6 LTS