### PR TITLE
Remove unused sqlite3 dependency

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -1,5 +1,10 @@
 # CARTO's CHANGELOG
 
+## v0.6.17-carto.3
+Released 20XX-XX-XX
+
+- Remove unused sqlite3 dependency.
+
 ## v0.6.17-carto.2
 Released 2018-10-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "millstone",
-    "version": "0.6.17-carto.1",
+    "version": "0.6.17-carto.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1199,16 +1199,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
-        "sqlite3": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.3.tgz",
-            "integrity": "sha512-nuWqc26oiJZXyY5MEz+rQbiki1BTibnXsy8Kqo7QD/ut6eksOWi6uWwFMbdnFNME7CZyplWdDXj2fbdQVaEfuA==",
-            "requires": {
-                "nan": "~2.10.0",
-                "node-pre-gyp": "^0.10.3",
-                "request": "^2.87.0"
-            }
         },
         "srs": {
             "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "millstone",
-    "version": "0.6.17-carto.2",
+    "version": "0.6.17-carto.3",
     "main": "./lib/millstone.js",
     "description": "Prepares datasources in an MML file for consumption in Mapnik",
     "url": "https://github.com/mapbox/millstone",
@@ -24,7 +24,6 @@
         "mkdirp": "~0.5.0",
         "optimist": "0.6.1",
         "request": "2.x",
-        "sqlite3": "~4.0.1",
         "srs": "^1.2.0",
         "step": "~1.0.0",
         "underscore": "~1.9.1",


### PR DESCRIPTION
As far as I can see, 30a3d2300426cb1deaf1cf1cfc7444084164c3a0 (8 years ago :upside_down_face:) removed the code that used this import, so it isn't a dependency.